### PR TITLE
[ME-4546] replace ioutil with io everywhere (Upstream #258)

### DIFF
--- a/internal/github.com/swisscom/mssql-always-encrypted/pkg/alwaysencrypted_test.go
+++ b/internal/github.com/swisscom/mssql-always-encrypted/pkg/alwaysencrypted_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -22,7 +22,7 @@ func TestLoadCEKV(t *testing.T) {
 	certFile, err := os.Open("../test/always-encrypted_pub.pem")
 	assert.NoError(t, err)
 
-	certBytes, err := ioutil.ReadAll(certFile)
+	certBytes, err := io.ReadAll(certFile)
 	assert.NoError(t, err)
 	pemB, _ := pem.Decode(certBytes)
 	cert, err := x509.ParseCertificate(pemB.Bytes)
@@ -30,7 +30,7 @@ func TestLoadCEKV(t *testing.T) {
 
 	cekvFile, err := os.Open("../test/cekv.key")
 	assert.NoError(t, err)
-	cekvBytes, err := ioutil.ReadAll(cekvFile)
+	cekvBytes, err := io.ReadAll(cekvFile)
 	assert.NoError(t, err)
 	cekv := LoadCEKV(cekvBytes)
 	assert.Equal(t, 1, cekv.Version)
@@ -40,7 +40,7 @@ func TestDecrypt(t *testing.T) {
 	certFile, err := os.Open("../test/always-encrypted.pem")
 	assert.NoError(t, err)
 
-	certBytes, err := ioutil.ReadAll(certFile)
+	certBytes, err := io.ReadAll(certFile)
 	assert.NoError(t, err)
 	pemB, _ := pem.Decode(certBytes)
 	privKey, err := x509.ParsePKCS8PrivateKey(pemB.Bytes)
@@ -50,7 +50,7 @@ func TestDecrypt(t *testing.T) {
 
 	cekvFile, err := os.Open("../test/cekv.key")
 	assert.NoError(t, err)
-	cekvBytes, err := ioutil.ReadAll(cekvFile)
+	cekvBytes, err := io.ReadAll(cekvFile)
 	assert.NoError(t, err)
 	cekv := LoadCEKV(cekvBytes)
 	rootKey, err := cekv.Decrypt(rsaPrivKey)
@@ -62,7 +62,7 @@ func TestDecrypt(t *testing.T) {
 	columnBytesFile, err := os.Open("../test/column_value.enc")
 	assert.NoError(t, err)
 
-	columnBytes, err := ioutil.ReadAll(columnBytesFile)
+	columnBytes, err := io.ReadAll(columnBytesFile)
 	assert.NoError(t, err)
 
 	key := keys.NewAeadAes256CbcHmac256(rootKey)
@@ -81,7 +81,7 @@ func TestDecryptCEK(t *testing.T) {
 	certFile, err := os.Open("../test/always-encrypted.pem")
 	assert.NoError(t, err)
 
-	certFileBytes, err := ioutil.ReadAll(certFile)
+	certFileBytes, err := io.ReadAll(certFile)
 	assert.NoError(t, err)
 
 	pemBlock, _ := pem.Decode(certFileBytes)
@@ -91,7 +91,7 @@ func TestDecryptCEK(t *testing.T) {
 	cekvFile, err := os.Open("../test/cekv.key")
 	assert.NoError(t, err)
 
-	cekvBytes, err := ioutil.ReadAll(cekvFile)
+	cekvBytes, err := io.ReadAll(cekvFile)
 	assert.NoError(t, err)
 
 	cekv := LoadCEKV(cekvBytes)

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 )
@@ -79,7 +78,7 @@ func BenchmarkSelect(b *testing.B) {
 		if packetType != packLogin7 {
 			b.Fatal("Client sent non LOGIN request packet type", packetType)
 		}
-		_, err = ioutil.ReadAll(tdsBuf)
+		_, err = io.ReadAll(tdsBuf)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -114,7 +113,7 @@ func BenchmarkSelect(b *testing.B) {
 				b.Log(err)
 				return
 			}
-			_, err = ioutil.ReadAll(tdsBuf)
+			_, err = io.ReadAll(tdsBuf)
 			if err != nil {
 				b.Log(err)
 				return

--- a/tds.go
+++ b/tds.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"sort"
@@ -280,7 +279,7 @@ func readPrelogin(r *tdsBuffer) (map[uint8][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	struct_buf, err := ioutil.ReadAll(r)
+	struct_buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/token.go
+++ b/token.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"strconv"
 
@@ -586,7 +585,7 @@ func parseFeatureExtAck(r *tdsBuffer) featureExtAck {
 
 		// Skip unprocessed bytes
 		if length > 0 {
-			io.CopyN(ioutil.Discard, r, int64(length))
+			io.CopyN(io.Discard, r, int64(length))
 		}
 	}
 


### PR DESCRIPTION
## [[ME-4546](https://mysocket.atlassian.net/browse/ME-4546)] Replace ioutil with io everywhere (#258)

[ME-4546]: https://mysocket.atlassian.net/browse/ME-4546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ