### PR TITLE
[ME-4578] Fix Client Disconnections, More Improvements

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -215,6 +215,10 @@ func (r *tdsBuffer) readNextPacket() error {
 }
 
 func (r *tdsBuffer) BeginRead() (packetType, error) {
+	if r.serverConn != nil {
+		resetSession := false
+		r.serverConn.buf.BeginPacket(r.rPacketType, resetSession)
+	}
 	err := r.readNextPacket()
 	if err != nil {
 		return 0, err

--- a/tds.go
+++ b/tds.go
@@ -156,6 +156,7 @@ const (
 	featExtAZURESQLSUPPORT    byte = 0x08
 	featExtDATACLASSIFICATION byte = 0x09
 	featExtUTF8SUPPORT        byte = 0x0A
+	featExtAZURESQLDNSCACHING byte = 0x0B
 	featExtTERMINATOR         byte = 0xFF
 )
 
@@ -563,7 +564,7 @@ func (f *featureExtUTF8Support) toBytes() []byte { return nil } // Can be []byte
 // AZURESQLDNSCACHING feature extension
 type featureExtAzureSQLDNSCaching struct{}
 
-func (f *featureExtAzureSQLDNSCaching) featureID() byte { return 0x0B }
+func (f *featureExtAzureSQLDNSCaching) featureID() byte { return featExtAZURESQLDNSCACHING }
 func (f *featureExtAzureSQLDNSCaching) toBytes() []byte { return nil }
 
 type loginHeader struct {
@@ -1095,12 +1096,24 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger Cont
 		ChangePassword: p.ChangePassword,
 		ClientPID:      uint32(os.Getpid()),
 	}
-	l.FeatureExt.Add(&featureExtSessionRecovery{})
-	l.FeatureExt.Add(&featureExtColumnEncryption{version: 0x03})
-	l.FeatureExt.Add(&featureExtGlobalTransactions{})
-	l.FeatureExt.Add(&featureExtDataClassification{version: 0x02})
-	l.FeatureExt.Add(&featureExtUTF8Support{})
-	l.FeatureExt.Add(&featureExtAzureSQLDNSCaching{})
+	if featAddErr := l.FeatureExt.Add(&featureExtSessionRecovery{}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtSessionRecovery: %v", featAddErr))
+	}
+	if featAddErr := l.FeatureExt.Add(&featureExtColumnEncryption{version: 0x03}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtColumnEncryption: %v", featAddErr))
+	}
+	if featAddErr := l.FeatureExt.Add(&featureExtGlobalTransactions{}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtGlobalTransactions: %v", featAddErr))
+	}
+	if featAddErr := l.FeatureExt.Add(&featureExtDataClassification{version: 0x02}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtDataClassification: %v", featAddErr))
+	}
+	if featAddErr := l.FeatureExt.Add(&featureExtUTF8Support{}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtUTF8Support: %v", featAddErr))
+	}
+	if featAddErr := l.FeatureExt.Add(&featureExtAzureSQLDNSCaching{}); featAddErr != nil {
+		logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("failed to set featureExtAzureSQLDNSCaching: %v", featAddErr))
+	}
 	getClientId(&l.ClientID)
 	if p.ColumnEncryption {
 		_ = l.FeatureExt.Add(&featureExtColumnEncryption{})


### PR DESCRIPTION
## [[ME-4578](https://mysocket.atlassian.net/browse/ME-4578)] Fix Client Disconnections, More Improvements

The change to `BeginRead` is code that got lost between release 1.6.5 and 1.6.6 and is necessary - or else some clients disconnect abruptly after each query.

The other changes are just code quality improvements.

[ME-4578]: https://mysocket.atlassian.net/browse/ME-4578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ